### PR TITLE
feat: allow customizing the dlq name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,12 @@ Terraform module which creates a sqs queue
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_dlq_queue_arn"></a> [dlq\_queue\_arn](#output\_dlq\_queue\_arn) | queue arn of the dead letter sqs queue |
+| <a name="output_dlq_queue_name"></a> [dlq\_queue\_name](#output\_dlq\_queue\_name) | queue name of the dead letter sqs queue |
+| <a name="output_dlq_queue_url"></a> [dlq\_queue\_url](#output\_dlq\_queue\_url) | queue url of the dead letter sqs queue |
+| <a name="output_sqs_queue_arn"></a> [sqs\_queue\_arn](#output\_sqs\_queue\_arn) | queue arn of the main sqs queue |
+| <a name="output_sqs_queue_name"></a> [sqs\_queue\_name](#output\_sqs\_queue\_name) | queue name of the main sqs queue |
+| <a name="output_sqs_queue_url"></a> [sqs\_queue\_url](#output\_sqs\_queue\_url) | queue url of the main sqs queue |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Terraform module which creates a sqs queue
 | <a name="input_dlq_alarm_enabled"></a> [dlq\_alarm\_enabled](#input\_dlq\_alarm\_enabled) | Defines if the DLQ alarm should be created. | `bool` | `true` | no |
 | <a name="input_dlq_enabled"></a> [dlq\_enabled](#input\_dlq\_enabled) | Defines if Dead Letter Queue (DLQ) is enabled. | `bool` | `true` | no |
 | <a name="input_dlq_max_receive_count"></a> [dlq\_max\_receive\_count](#input\_dlq\_max\_receive\_count) | The maximum number of times a message can be received from the DLQ before it's discarded. | `number` | `5` | no |
+| <a name="input_dlq_name"></a> [dlq\_name](#input\_dlq\_name) | Sets a custom name for the to be created dlq. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | Boolean designating a FIFO queue | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ module "sqs" {
   create_dlq                = var.dlq_enabled
   create_queue_policy       = length(var.subscription) >= 1
   delay_seconds             = var.delay_seconds
+  dlq_name                  = var.dlq_name
   fifo_queue                = var.fifo_queue
   message_retention_seconds = var.message_retention_seconds
   name                      = module.this.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,28 @@
+output "sqs_queue_url" {
+  value       = module.sqs.queue_url
+  description = "queue url of the main sqs queue"
+}
+output "sqs_queue_arn" {
+  value       = module.sqs.queue_arn
+  description = "queue arn of the main sqs queue"
+}
+
+output "sqs_queue_name" {
+  value       = module.sqs.queue_name
+  description = "queue name of the main sqs queue"
+}
+
+output "dlq_queue_url" {
+  value       = module.sqs.dead_letter_queue_url
+  description = "queue url of the dead letter sqs queue"
+}
+
+output "dlq_queue_arn" {
+  value       = module.sqs.dead_letter_queue_arn
+  description = "queue arn of the dead letter sqs queue"
+}
+
+output "dlq_queue_name" {
+  value       = module.sqs.dead_letter_queue_name
+  description = "queue name of the dead letter sqs queue"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "dlq_max_receive_count" {
   default     = 5
 }
 
+variable "dlq_name" {
+  type        = string
+  description = "Sets a custom name for the to be created dlq."
+  default     = null
+}
+
 variable "fifo_queue" {
   type        = bool
   description = "Boolean designating a FIFO queue"


### PR DESCRIPTION
## Description
Allow specifying the name of the created dlq compared to using normal queue name + "-dlq".

## Motivation and Context
We want to have a custom named sqs queue from which we can read using a different consumer, as such the default -dlq ending would be misleading.

## Breaking Changes
Not applicable.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
